### PR TITLE
set comments and commentstring

### DIFF
--- a/ftplugin/hjson.vim
+++ b/ftplugin/hjson.vim
@@ -1,0 +1,2 @@
+setlocal commentstring=#\ %s
+setlocal comments=:#

--- a/ftplugin/hjson.vim
+++ b/ftplugin/hjson.vim
@@ -1,2 +1,2 @@
 setlocal commentstring=#\ %s
-setlocal comments=:#
+setlocal comments=:#,://,s1:/*,m:*,ex:*/


### PR DESCRIPTION
These variables are documented e.g. [here](https://vimhelp.org/options.txt.html#%27comments%27).

For comparison other language plugins also set these two variables [vim-go](https://github.com/fatih/vim-go/blob/master/ftplugin/go.vim#L22) or [vim-toml](https://github.com/cespare/vim-toml/blob/main/ftplugin/toml.vim#L18).

I used these variables through the [tcomment](https://github.com/tomtom/tcomment_vim) plugin. e.g. `gcc` toggles whether the current line is commented in or out.