### PR TITLE
fixes, green non-string values

### DIFF
--- a/syntax/hjson.vim
+++ b/syntax/hjson.vim
@@ -42,9 +42,9 @@ syn match   hjsonNull      /null\ze\s*\($\|[\]}#,]\|\/\/\|\/\*\)/
 syn match   hjsonKeywordMatch /\(:\_s*\)\@<![^,:[\]{}[:blank:]]\+\_s*:/ contains=hjsonKeyword
 syn region  hjsonKeyword matchgroup=hjsonQuote start=//  end=/\ze\_s*:/ contained
 " with quotes
-syn match   hjsonKeywordMatchQ /"\([^"]\|\\\"\)\+"\_s*:/ contains=hjsonKeywordQ,hjsonEscape
+syn match   hjsonKeywordMatchQ /\(:\_s*\)\@<!"\([^"]\|\\\"\)\+"\_s*:/ contains=hjsonKeywordQ,hjsonEscape
 syn region  hjsonKeywordQ matchgroup=hjsonQuote start=/"/  end=/"\ze\_s*:/ contains=hjsonEscape contained
-syn match   hjsonKeywordMatchSQ /'\([^']\|\\\'\)\+'\_s*:/ contains=hjsonKeywordSQ,hjsonEscape
+syn match   hjsonKeywordMatchSQ /\(:\_s*\)\@<!'\([^']\|\\\'\)\+'\_s*:/ contains=hjsonKeywordSQ,hjsonEscape
 syn region  hjsonKeywordSQ matchgroup=hjsonQuote start=/'/  end=/'\ze\_s*:/ contains=hjsonEscape contained
 
 " Syntax: Escape sequences

--- a/syntax/hjson.vim
+++ b/syntax/hjson.vim
@@ -13,43 +13,39 @@ if !exists("main_syntax")
 endif
 
 " quoteless Strings (has least priority)
-syn match   hjsonStringUQ      /[^ \t].*$/
+syn match   hjsonStringUQ      /[^ \t,:[\]{}].*$/
 
 syn match   hjsonNoise         /\%(:\|,\)/
 
-" Syntax: Comments
-syn match   hjsonLineComment   "\/\/.*"
-syn match   hjsonLineComment2  "#.*"
-syn region  hjsonComment       start="/\*" end="\*/"
-
 " Syntax: Strings
 " Separated into a match and region because a region by itself is always greedy
-syn match   hjsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n,}\]#\/]/ contains=hjsonString
+syn match   hjsonStringMatch /"\([^"]\|\\\"\)*"/ contains=hjsonString
 syn region  hjsonString oneline matchgroup=hjsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=hjsonEscape contained
-syn match   hjsonStringMatchSQ /'\([^']\|\\\'\)\+'\ze[[:blank:]\r\n,}\]#\/]/ contains=hjsonStringSQ
+syn match   hjsonStringMatchSQ /'\([^']\|\\\'\)*'/ contains=hjsonStringSQ
 syn region  hjsonStringSQ oneline matchgroup=hjsonQuote start=/'/  skip=/\\\\\|\\'/  end=/'/ contains=hjsonEscape contained
 " multiline:
 syn match   hjsonStringMatchML /'''\([\r\n]\|.\)\{-}'''/ contains=hjsonStringML
 syn region  hjsonStringML matchgroup=hjsonQuote start=/'''/ end=/'''/ contained
 
 " Syntax: Numbers
-syn match   hjsonNumber    "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>\ze[[:blank:]\r\n,}\]]"
+syn match   hjsonNumber    "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>\ze\s*\($\|[\]}#,]\|\/\/\|\/\*\)"
 
 " Syntax: Boolean
-syn match   hjsonBoolean   /\(true\|false\)\ze\_s*[\]}#\/,\r\n]/
+syn match   hjsonBoolean   /\(true\|false\)\ze\s*\($\|[\]}#,]\|\/\/\|\/\*\)/
 
 " Syntax: Null
-syn match   hjsonNull      /null\ze\_s*[\]}#\/,\r\n]/
+syn match   hjsonNull      /null\ze\s*\($\|[\]}#,]\|\/\/\|\/\*\)/
 
 " Syntax: JSON Object Keywords
 " Separated into a match and region because a region by itself is always greedy
-syn match   hjsonKeywordMatchQ /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=hjsonKeywordQ
-syn region  hjsonKeywordQ matchgroup=hjsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained
-syn match   hjsonKeywordMatchSQ /'\([^']\|\\\'\)\+'[[:blank:]\r\n]*\:/ contains=hjsonKeywordSQ
-syn region  hjsonKeywordSQ matchgroup=hjsonQuote start=/'/  end=/'\ze[[:blank:]\r\n]*\:/ contained
 " without quotes
-syn match   hjsonKeywordMatch /[^][",:{}[:blank:]]\+\:/ contains=hjsonKeyword
-syn region  hjsonKeyword matchgroup=hjsonQuote start=//  end=/\ze\:/ contained
+syn match   hjsonKeywordMatch /\(:\_s*\)\@<![^,:[\]{}[:blank:]]\+\_s*:/ contains=hjsonKeyword
+syn region  hjsonKeyword matchgroup=hjsonQuote start=//  end=/\ze\_s*:/ contained
+" with quotes
+syn match   hjsonKeywordMatchQ /"\([^"]\|\\\"\)\+"\_s*:/ contains=hjsonKeywordQ,hjsonEscape
+syn region  hjsonKeywordQ matchgroup=hjsonQuote start=/"/  end=/"\ze\_s*:/ contains=hjsonEscape contained
+syn match   hjsonKeywordMatchSQ /'\([^']\|\\\'\)\+'\_s*:/ contains=hjsonKeywordSQ,hjsonEscape
+syn region  hjsonKeywordSQ matchgroup=hjsonQuote start=/'/  end=/'\ze\_s*:/ contains=hjsonEscape contained
 
 " Syntax: Escape sequences
 syn match   hjsonEscape    "\\["'\\/bfnrt]" contained
@@ -59,6 +55,11 @@ syn match   hjsonEscape    "\\u\x\{4}" contained
 syn region  hjsonFold matchgroup=hjsonBraces start="{" end=/}\(\_s\+\ze\("\|{\)\)\@!/ transparent fold
 syn region  hjsonFold matchgroup=hjsonBraces start="\[" end=/]\(\_s\+\ze"\)\@!/ transparent fold
 
+" Syntax: Comments
+syn match   hjsonLineComment   "\/\/.*"
+syn match   hjsonLineComment2  "#.*"
+syn region  hjsonComment       start="/\*" end="\*/"
+
 " Define the default highlighting.
 hi def link hjsonComment         Comment
 hi def link hjsonLineComment     hjsonComment
@@ -67,15 +68,15 @@ hi def link hjsonString          String
 hi def link hjsonStringSQ        hjsonString
 hi def link hjsonStringML        hjsonString
 hi def link hjsonStringUQ        hjsonString
-hi def link hjsonEscape          Character "Special
-hi def link hjsonNumber          Number
+hi def link hjsonEscape          Special
+hi def link hjsonNumber          Type
 hi def link hjsonBraces          Delimiter
-hi def link hjsonNull            Function
-hi def link hjsonBoolean         Boolean
+hi def link hjsonNull            Type
+hi def link hjsonBoolean         Type
 hi def link hjsonKeyword         Label
 hi def link hjsonKeywordQ        hjsonKeyword
 hi def link hjsonKeywordSQ       hjsonKeyword
-hi def link hjsonQuote           Character "Quote
+hi def link hjsonQuote           Delimiter
 hi def link hjsonNoise           Noise
 
 let b:current_syntax = "hjson"


### PR DESCRIPTION
Fixes #6 and other issues.

Non-string values (number, bool, null) now have a different color than strings (default green for non-strings and purple for strings in dark mode).